### PR TITLE
Fix precedence error in A.E. Fences patch

### DIFF
--- a/Patches/Patches.xml
+++ b/Patches/Patches.xml
@@ -22,7 +22,7 @@
 			<success>Always</success>
 			<operations>
 				<li Class="PatchOperationAdd">
-					<xpath>Defs/ThingDef[@ParentName="WoodMetalFence" or @ParentName="WoodMetalGate" or @ParentName="WoodFence" or @ParentName="MetalFence" or @ParentName="MetalGate" and not(terrainAffordanceNeeded)]</xpath>
+					<xpath>Defs/ThingDef[(@ParentName="WoodMetalFence" or @ParentName="WoodMetalGate" or @ParentName="WoodFence" or @ParentName="MetalFence" or @ParentName="MetalGate") and not(terrainAffordanceNeeded)]</xpath>
 					<value>
 						<terrainAffordanceNeeded/>
 					</value>


### PR DESCRIPTION
After reporting my bug in the steam workshop I noticed your mod was open source and decided to try to help! Thanks for going with open source. :) 

Steam comment copied over for posterity:

> Unfortunately it looks like it's not quite patching Architect Expanded - Fences correctly in my mod list. It's creating two terrainAffordance tags which appears as an error in the logs, and they can't be placed on any terrain at all in game. :(
> 
> Example error for the closeboard fence: https://pastebin.com/HCUSGx66
> 
> Modlist is... substantial. :( https://pastebin.com/6kB8zc8e
> 
> Happy to try a few reconfigurations if you have any thoughts to save you some time if you get around to looking into this. Would love to be able to use your mod.

The fix was quite easy! The patch was accidentally adding a second terrainAffordanceNeeded tag due to the `and` xpath operator having a higher binding precedence than the `or` operator, which means 


```
Defs/ThingDef[@ParentName="WoodMetalFence" or @ParentName="WoodMetalGate" or @ParentName="WoodFence" or @ParentName="MetalFence" or @ParentName="MetalGate" and not(terrainAffordanceNeeded)]
```

was interpreted as 
```
Defs/ThingDef[@ParentName="WoodMetalFence" or @ParentName="WoodMetalGate" or @ParentName="WoodFence" or @ParentName="MetalFence" or 

(@ParentName="MetalGate" and not(terrainAffordanceNeeded))]
```

so only the MetalGate was properly prevented from adding an extra tag.